### PR TITLE
Migrate portlet to Jakarta EE / Liferay 2026.q1 baseline

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@
 
 liferay.workspace.modules.dir=modules
 microsoft.translator.subscription.key=
-liferay.workspace.product=portal-7.4-ga112
+liferay.workspace.product=dxp-2026.q1.9-lts

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/index-checker/bnd.bnd
+++ b/modules/index-checker/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: index-checker
 Bundle-SymbolicName: jorgediazest.indexchecker.portlet
-Bundle-Version: 1.1.0
+Bundle-Version: 2.0.0
 Export-Package: jorgediazest.indexchecker.portlet.constants
 Provide-Capability:\
 	liferay.language.resources;\

--- a/modules/index-checker/build.gradle
+++ b/modules/index-checker/build.gradle
@@ -1,10 +1,14 @@
 dependencies {
-	compileInclude group: "org.yaml", name: "snakeyaml", version: "1.18"
+	compileInclude(group: "org.yaml", name: "snakeyaml") {
+		version {
+			strictly "1.33"
+		}
+	}
 	compileInclude project(":modules:output-utils")
 	compileInclude project(":modules:servicebuilder-query-data")
 	compileInclude project(":modules:servicebuilder-reflection")
 
-	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
 
 	cssBuilder group: "com.liferay", name: "com.liferay.css.builder", version: "3.0.2"
 }

--- a/modules/index-checker/build.gradle
+++ b/modules/index-checker/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	compileInclude project(":modules:servicebuilder-query-data")
 	compileInclude project(":modules:servicebuilder-reflection")
 
-	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
 
 	cssBuilder group: "com.liferay", name: "com.liferay.css.builder", version: "3.0.2"
 }

--- a/modules/index-checker/build.gradle
+++ b/modules/index-checker/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	compileInclude project(":modules:servicebuilder-query-data")
 	compileInclude project(":modules:servicebuilder-reflection")
 
-	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
 
 	cssBuilder group: "com.liferay", name: "com.liferay.css.builder", version: "3.0.2"
 }

--- a/modules/index-checker/src/main/java/jorgediazest/indexchecker/output/IndexCheckerOutput.java
+++ b/modules/index-checker/src/main/java/jorgediazest/indexchecker/output/IndexCheckerOutput.java
@@ -35,9 +35,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
-import javax.portlet.PortletConfig;
-import javax.portlet.PortletURL;
-import javax.portlet.RenderRequest;
+import jakarta.portlet.PortletConfig;
+import jakarta.portlet.PortletURL;
+import jakarta.portlet.RenderRequest;
 
 import jorgediazest.indexchecker.ExecutionMode;
 

--- a/modules/index-checker/src/main/java/jorgediazest/indexchecker/portlet/IndexCheckerConfiguration.java
+++ b/modules/index-checker/src/main/java/jorgediazest/indexchecker/portlet/IndexCheckerConfiguration.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 @Component(
 	configurationPid = "jorgediazest.indexchecker.portlet.IndexCheckerConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
-	property = "javax.portlet.name=" + IndexCheckerKeys.INDEXCHECKER,
+	property = "jakarta.portlet.name=" + IndexCheckerKeys.INDEXCHECKER,
 	service = ConfigurationAction.class
 )
 public class IndexCheckerConfiguration extends DefaultConfigurationAction {

--- a/modules/index-checker/src/main/java/jorgediazest/indexchecker/portlet/IndexCheckerControlPanelEntry.java
+++ b/modules/index-checker/src/main/java/jorgediazest/indexchecker/portlet/IndexCheckerControlPanelEntry.java
@@ -41,11 +41,11 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import javax.portlet.PortletRequest;
-import javax.portlet.PortletURL;
+import jakarta.portlet.PortletRequest;
+import jakarta.portlet.PortletURL;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import jorgediazest.indexchecker.portlet.constants.IndexCheckerKeys;
 
@@ -79,7 +79,7 @@ public class IndexCheckerControlPanelEntry implements PanelApp {
 
 			return LanguageUtil.get(
 				resourceBundle,
-				JavaConstants.JAVAX_PORTLET_TITLE + StringPool.PERIOD +
+				JavaConstants.JAKARTA_PORTLET_TITLE + StringPool.PERIOD +
 					getPortletId());
 		}
 		catch (MissingResourceException missingResourceException) {
@@ -90,7 +90,7 @@ public class IndexCheckerControlPanelEntry implements PanelApp {
 
 		return LanguageUtil.get(
 			locale,
-			JavaConstants.JAVAX_PORTLET_TITLE + StringPool.PERIOD +
+			JavaConstants.JAKARTA_PORTLET_TITLE + StringPool.PERIOD +
 				getPortletId());
 	}
 
@@ -202,7 +202,7 @@ public class IndexCheckerControlPanelEntry implements PanelApp {
 		IndexCheckerControlPanelEntry.class);
 
 	@Reference(
-		target = "(javax.portlet.name=" + IndexCheckerKeys.INDEXCHECKER + ")"
+		target = "(jakarta.portlet.name=" + IndexCheckerKeys.INDEXCHECKER + ")"
 	)
 	private Portlet _portlet;
 

--- a/modules/index-checker/src/main/java/jorgediazest/indexchecker/portlet/IndexCheckerPortlet.java
+++ b/modules/index-checker/src/main/java/jorgediazest/indexchecker/portlet/IndexCheckerPortlet.java
@@ -70,17 +70,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import javax.portlet.ActionRequest;
-import javax.portlet.ActionResponse;
-import javax.portlet.Portlet;
-import javax.portlet.PortletConfig;
-import javax.portlet.PortletException;
-import javax.portlet.PortletPreferences;
-import javax.portlet.RenderRequest;
-import javax.portlet.RenderResponse;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
-import javax.portlet.ResourceURL;
+import jakarta.portlet.ActionRequest;
+import jakarta.portlet.ActionResponse;
+import jakarta.portlet.Portlet;
+import jakarta.portlet.PortletConfig;
+import jakarta.portlet.PortletException;
+import jakarta.portlet.PortletPreferences;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
+import jakarta.portlet.ResourceURL;
 
 import jorgediazest.indexchecker.ExecutionMode;
 import jorgediazest.indexchecker.index.IndexSearchHelper;
@@ -117,16 +117,17 @@ import org.osgi.service.component.annotations.Component;
 		"com.liferay.portlet.icon=/icon.png",
 		"com.liferay.portlet.instanceable=false",
 		"com.liferay.portlet.single-page-application=false",
-		"javax.portlet.display-name=Index Checker",
-		"javax.portlet.info.keywords=search,index,check,checker,verify,reindex,lucene,solr,elasticsearch",
-		"javax.portlet.info.short-title=Index Checker",
-		"javax.portlet.info.title=Index Checker",
-		"javax.portlet.init-param.template-path=/",
-		"javax.portlet.init-param.config-template=/html/indexchecker/config.jsp",
-		"javax.portlet.init-param.view-template=/html/indexchecker/view.jsp",
-		"javax.portlet.name=" + IndexCheckerKeys.INDEXCHECKER,
-		"javax.portlet.portlet-name=index_checker",
-		"javax.portlet.security-role-ref=administrator,power-user,user"
+		"jakarta.portlet.display-name=Index Checker",
+		"jakarta.portlet.info.keywords=search,index,check,checker,verify,reindex,lucene,solr,elasticsearch",
+		"jakarta.portlet.info.short-title=Index Checker",
+		"jakarta.portlet.info.title=Index Checker",
+		"jakarta.portlet.init-param.template-path=/",
+		"jakarta.portlet.init-param.config-template=/html/indexchecker/config.jsp",
+		"jakarta.portlet.init-param.view-template=/html/indexchecker/view.jsp",
+		"jakarta.portlet.name=" + IndexCheckerKeys.INDEXCHECKER,
+		"jakarta.portlet.portlet-name=index_checker",
+		"jakarta.portlet.security-role-ref=administrator,power-user,user",
+		"jakarta.portlet.version=4.0"
 	},
 	service = Portlet.class
 )
@@ -435,7 +436,7 @@ public class IndexCheckerPortlet extends MVCPortlet {
 		throws IOException, PortletException {
 
 		PortletConfig portletConfig = (PortletConfig)renderRequest.getAttribute(
-			JavaConstants.JAVAX_PORTLET_CONFIG);
+			JavaConstants.JAKARTA_PORTLET_CONFIG);
 
 		List<String> outputList = IndexCheckerOutput.generateCSVOutput(
 			portletConfig, renderRequest);
@@ -1177,7 +1178,7 @@ public class IndexCheckerPortlet extends MVCPortlet {
 		throws IOException, PortletException {
 
 		PortletConfig portletConfig = (PortletConfig)request.getAttribute(
-			JavaConstants.JAVAX_PORTLET_CONFIG);
+			JavaConstants.JAKARTA_PORTLET_CONFIG);
 
 		String portletId = portletConfig.getPortletName();
 

--- a/modules/index-checker/src/main/resources/META-INF/resources/html/indexchecker/config.jsp
+++ b/modules/index-checker/src/main/resources/META-INF/resources/html/indexchecker/config.jsp
@@ -16,12 +16,6 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/sql" prefix="sql" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
-
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %>
 <%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
 <%@ taglib uri="http://liferay.com/tld/security" prefix="liferay-security" %>

--- a/modules/index-checker/src/main/resources/META-INF/resources/html/indexchecker/view.jsp
+++ b/modules/index-checker/src/main/resources/META-INF/resources/html/indexchecker/view.jsp
@@ -16,12 +16,6 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/sql" prefix="sql" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
-
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %>
 <%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
 <%@ taglib uri="http://liferay.com/tld/security" prefix="liferay-security" %>
@@ -50,7 +44,7 @@
 <%@ page import="java.util.Map.Entry" %>
 <%@ page import="java.util.Set" %>
 
-<%@ page import="javax.portlet.PortletURL" %>
+<%@ page import="jakarta.portlet.PortletURL" %>
 
 <%@ page import="jorgediazest.indexchecker.ExecutionMode" %>
 <%@ page import="jorgediazest.indexchecker.output.IndexCheckerOutput" %>
@@ -313,9 +307,13 @@ if (filterGroupIdSelected.contains("-2")) {
 			String errorMessage = companyError.get(companyEntry.getKey());
 %>
 
-<c:if test="<%= Validator.isNotNull(errorMessage) %>">
+<%
+if (Validator.isNotNull(errorMessage)) {
+%>
 	<aui:input cssClass="lfr-textarea-container" name="output" resizable="<%= true %>" type="textarea" value="<%= errorMessage %>" />
-</c:if>
+<%
+}
+%>
 
 <i>Executed <b><%= request.getAttribute("title") %></b> for instance <%= companyEntry.getKey().getCompanyId() %> in <%=processTime %> ms</i><br />
 

--- a/modules/output-utils/bnd.bnd
+++ b/modules/output-utils/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: output-utils
 Bundle-SymbolicName: jorgediazest.output.utils
-Bundle-Version: 1.1.0
+Bundle-Version: 2.0.0
 Export-Package: jorgediazest.util.output
 -sources: true

--- a/modules/output-utils/build.gradle
+++ b/modules/output-utils/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
 	api project(":modules:servicebuilder-query-data")
 
-	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
 }

--- a/modules/output-utils/build.gradle
+++ b/modules/output-utils/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
 	api project(":modules:servicebuilder-query-data")
 
-	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
 }

--- a/modules/output-utils/build.gradle
+++ b/modules/output-utils/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compile project(":modules:servicebuilder-query-data")
+	api project(":modules:servicebuilder-query-data")
 
-	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
 }

--- a/modules/output-utils/src/main/java/jorgediazest/util/output/OutputUtils.java
+++ b/modules/output-utils/src/main/java/jorgediazest/util/output/OutputUtils.java
@@ -47,11 +47,11 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
 
-import javax.portlet.PortletConfig;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
+import jakarta.portlet.PortletConfig;
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import jorgediazest.util.data.Comparison;
 import jorgediazest.util.data.Data;

--- a/modules/servicebuilder-query-data/bnd.bnd
+++ b/modules/servicebuilder-query-data/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: servicebuilder-query-data
 Bundle-SymbolicName: jorgediazest.servicebuilder.query.data
-Bundle-Version: 1.1.0
+Bundle-Version: 2.0.0
 Export-Package:\
 	jorgediazest.util.comparator,\
 	jorgediazest.util.data,\

--- a/modules/servicebuilder-query-data/build.gradle
+++ b/modules/servicebuilder-query-data/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
 	api project(":modules:servicebuilder-reflection")
 
-	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
 }

--- a/modules/servicebuilder-query-data/build.gradle
+++ b/modules/servicebuilder-query-data/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compile project(":modules:servicebuilder-reflection")
+	api project(":modules:servicebuilder-reflection")
 
-	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
 }

--- a/modules/servicebuilder-query-data/build.gradle
+++ b/modules/servicebuilder-query-data/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
 	api project(":modules:servicebuilder-reflection")
 
-	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
 }

--- a/modules/servicebuilder-reflection/bnd.bnd
+++ b/modules/servicebuilder-reflection/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: servicebuilder-reflection
 Bundle-SymbolicName: jorgediazest.servicebuilder.reflection
-Bundle-Version: 1.1.0
+Bundle-Version: 2.0.0
 Export-Package:\
 	jorgediazest.util.model,\
 	jorgediazest.util.reflection,\

--- a/modules/servicebuilder-reflection/build.gradle
+++ b/modules/servicebuilder-reflection/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
 }

--- a/modules/servicebuilder-reflection/build.gradle
+++ b/modules/servicebuilder-reflection/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-	compileOnly group: "com.liferay.portal", name: "release.dxp.api"
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,11 @@
 buildscript {
 	dependencies {
-		classpath group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "5.2.0"
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "3.4.8") {
-			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
-		}
-		classpath group: "net.saliman", name: "gradle-properties-plugin", version: "1.4.6"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "15.0.0"
 	}
 
 	repositories {
+		mavenLocal()
+
 		maven {
 			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
 		}
@@ -18,7 +16,5 @@ buildscript {
 	}
 
 }
-
-apply plugin: "net.saliman.properties"
 
 apply plugin: "com.liferay.workspace"


### PR DESCRIPTION
Migrates the portlet to build and deploy against Liferay 2026.q1, which
fully removed the javax.* namespace in favor of Jakarta EE.